### PR TITLE
fix: stabilize hero layout during load

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -5,10 +5,14 @@ import ThemeToggle from "../components/ThemeToggle.tsx";
 export interface Props {
   title?: string;
   currentPage?: string;
+  preloadImages?: Array<{ src: string }>;
 }
 
-const { title = "Mark Wylde - Personal Portfolio", currentPage = "home" } =
-  Astro.props;
+const {
+  title = "Mark Wylde - Personal Portfolio",
+  currentPage = "home",
+  preloadImages = [],
+} = Astro.props;
 ---
 
 <!doctype html>
@@ -19,6 +23,9 @@ const { title = "Mark Wylde - Personal Portfolio", currentPage = "home" } =
 		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 		<meta name="generator" content={Astro.generator} />
 		<title>{title}</title>
+		{preloadImages.map((image) => <link rel="preload" as="image" href={image.src} />)}
+		<link rel="preconnect" href="https://fonts.googleapis.com">
+		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 		<link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;400;600;700&display=swap" rel="stylesheet">
 		<script is:inline>
 			(function() {
@@ -34,7 +41,7 @@ const { title = "Mark Wylde - Personal Portfolio", currentPage = "home" } =
 			<div class="container site-header-content">
 				<div class="header-left">
 					<a href="/" class="header-avatar-link">
-						<video autoplay muted class="header-avatar" playsinline poster={avatarHeaderFallback.src}>
+						<video autoplay muted class="header-avatar" playsinline poster={avatarHeaderFallback.src} width="75" height="75">
 							<source src={avatarVideoMp4} type="video/mp4" />
 							<img src={avatarHeaderFallback.src} alt="Mark Wylde - Avatar" />
 						</video>
@@ -120,6 +127,7 @@ const { title = "Mark Wylde - Personal Portfolio", currentPage = "home" } =
 		--shadow-color: rgba(0, 0, 0, 0.05);
 		--hero-bg: #f1f5f9;
 		--avatar-bg: #f8fafc;
+		--container-padding: 20px;
 	}
 
 	[data-theme="dark"] {
@@ -149,9 +157,10 @@ const { title = "Mark Wylde - Personal Portfolio", currentPage = "home" } =
 	}
 
 	.container {
+		width: 100%;
 		max-width: 1400px;
 		margin: auto;
-		padding: 0 20px;
+		padding: 0 var(--container-padding);
 		overflow: hidden;
 	}
 
@@ -432,7 +441,7 @@ const { title = "Mark Wylde - Personal Portfolio", currentPage = "home" } =
 		}
 
 		.container {
-			padding: 0 10px;
+			--container-padding: 10px;
 		}
 
 		.section {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -80,9 +80,16 @@ const personalProjects = [
 ];
 ---
 
-<Layout title="Mark Wylde - Personal Portfolio" currentPage="home">
+<Layout
+	title="Mark Wylde - Personal Portfolio"
+	currentPage="home"
+	preloadImages={[avatarImage]}
+>
 	<header class="hero">
-		<div class="container">
+		<div
+			class="container"
+			style="width: 100%; max-width: 1400px; margin: auto; padding: 0 var(--container-padding, 20px); overflow: hidden;"
+		>
 			<div class="hero-content">
 				<div class="hero-text">
 					<p class="name">Hi, I'm Mark Wylde</p>
@@ -128,7 +135,16 @@ const personalProjects = [
 					</div>
 				</div>
 				<div class="hero-avatar">
-					<img src={avatarImage.src} alt="Mark Wylde - Avatar" class="hero-image" />
+					<img
+						src={avatarImage.src}
+						width={avatarImage.width}
+						height={avatarImage.height}
+						alt="Mark Wylde - Avatar"
+						class="hero-image"
+						loading="eager"
+						decoding="async"
+						fetchpriority="high"
+					/>
 				</div>
 			</div>
 
@@ -293,18 +309,26 @@ const personalProjects = [
 		border-bottom: 1px solid var(--border-color);
 	}
 
+	.hero > .container {
+		width: 100%;
+		max-width: 1400px;
+		margin: auto;
+		padding: 0 var(--container-padding);
+		overflow: hidden;
+	}
+
 	.hero-content {
-		display: flex;
-		flex-wrap: wrap;
+		display: grid;
+		grid-template-columns: minmax(0, 1fr) minmax(300px, 450px);
 		align-items: center;
 		justify-content: space-between;
 		width: 100%;
-		gap: 40px;
+		gap: clamp(40px, 8vw, 140px);
 	}
 
 	.hero-text {
-		flex: 1.5;
-		min-width: 300px;
+		min-width: 0;
+		max-width: 760px;
 	}
 
 	.hero-text .name {
@@ -394,17 +418,18 @@ const personalProjects = [
 	}
 
 	.hero-avatar {
-		flex: 1;
-		min-width: 300px;
 		display: flex;
 		justify-content: center;
 		align-items: center;
+		justify-self: center;
+		width: min(100%, 450px);
+		aspect-ratio: 1;
 	}
 
 	.hero-avatar img {
+		aspect-ratio: 1;
 		width: 100%;
-		max-width: 450px;
-		height: auto;
+		height: 100%;
 		object-fit: contain;
 	}
 
@@ -641,7 +666,7 @@ const personalProjects = [
 		.hero-text .tagline { font-size: 1.25rem; }
 
 		.hero-content {
-			flex-direction: column;
+			grid-template-columns: 1fr;
 			text-align: left;
 			gap: 40px;
 		}


### PR DESCRIPTION
## Summary
- Keep the hero container on the 1400px centered rail during initial paint
- Reserve the hero avatar dimensions and preload the image
- Preserve responsive container padding through a shared CSS variable

## Verification
- npm run build
- Browser check under Slow 3G + 4x CPU: hero container computed at max-width 1400px with auto margins and CLS 0

## Notes
- npm run lint still fails on pre-existing Biome schema and ThemeToggle SVG title issues outside this change